### PR TITLE
Fix: Websocket authentication by query param

### DIFF
--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -30,13 +30,8 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   async handleConnection(client: Socket) {
     try {
-      // TODO: 앱 프레임워크인 ReactNative에서 Websocket 연결 시 쿠키 전달 방법이 있는지 확인
-      // 만약, 쿠키 전달을 하지 못한다면 인증 로직 수정해야 함
-      const cookies = client.handshake.headers.cookie;
-      const token = cookies
-        ?.split('; ')
-        ?.find((cookie) => cookie.startsWith('Authentication='))
-        ?.split('=')[1];
+      // NOTE: ReactNative에서 웹소켓 연결 시 쿠키 전달이 불가해 쿼리 파라미터로 토큰 전달
+      const token = client.handshake.query.authentication as string;
 
       if (!token) {
         throw new WsException({


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#31 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 웹소켓 연결 시 React Native에서 쿠키 지원을 해주지 않아 인증 방식을 쿼리 파라미터에 토큰을 보내고 검증하는 방식으로 변경
- 쿼리 파라미터 노출 등 보안 문제 검증 필요

### 스크린샷 (선택)

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/2e34597b-7eac-4621-9ed0-d435804070ee" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
