### PR TITLE
Fix/chat default get message return

### DIFF
--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -71,7 +71,7 @@ export class ChatService {
     const baseMessage = await queryBuilder.getOne();
 
     if (!baseMessage) {
-      throw new NotFoundException('기준 메세지를 찾을 수 없습니다.');
+      return [];
     }
 
     const cursorId = baseMessage.id;

--- a/src/chat/entities/chat.entity.ts
+++ b/src/chat/entities/chat.entity.ts
@@ -1,9 +1,11 @@
 import {
   Column,
+  CreateDateColumn,
   Entity,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 import { Exclude } from 'class-transformer';
 import { ApiHideProperty } from '@nestjs/swagger';
@@ -11,9 +13,8 @@ import { ApiHideProperty } from '@nestjs/swagger';
 import { ChatMessageType } from 'src/chat/entities/chat.meta';
 import { Room } from 'src/room/entities/room.entity';
 import { User } from 'src/user/entities/user.entity';
-import { Base } from 'src/common/base.entity';
 @Entity()
-export class Chat extends Base {
+export class Chat {
   @PrimaryGeneratedColumn('increment')
   @ApiHideProperty()
   @Exclude()
@@ -41,6 +42,12 @@ export class Chat extends Base {
     default: ChatMessageType.TEXT,
   })
   messageType: ChatMessageType;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 
   /**
    * Database Relation


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

없음

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- /chat/{roomUuid} Get 요청 시 
 - 방에 채팅 내역이 없다면 에러가 아니라 빈 배열을 리턴함
 - createdAt, updatedAt 을 리턴해 프론트에서 전송/수정 시각 표시 가능하게끔 변경

TODO: 추후 메세지 읽음 기능 구현

### 스크린샷 (선택)

변경된 GET /chat/{roomUuid} 리턴 스키마
![image](https://github.com/user-attachments/assets/c9ca6292-10b6-4c71-b905-4cd914156f3a)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

