### PR TITLE
Fix/websocket handle connection exception

### DIFF
--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
 import { JwtService } from '@nestjs/jwt';
-import { UseFilters } from '@nestjs/common';
+import { Logger, UseFilters } from '@nestjs/common';
 
 import { JwtPayload } from 'src/auth/strategies/jwt.payload';
 import { RoomService } from 'src/room/room.service';
@@ -59,7 +59,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       });
       client.disconnect();
       // 서버에 로그남기는 용도
-      console.log(`웹소켓 연결에 실패했습니다. ${error.message}`);
+      Logger.error(`웹소켓 연결에 실패했습니다. ${error}`);
     }
   }
 

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -28,6 +28,8 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     private readonly roomService: RoomService,
   ) {}
 
+  private readonly logger = new Logger(ChatGateway.name);
+
   async handleConnection(client: Socket) {
     try {
       // NOTE: ReactNative에서 웹소켓 연결 시 쿠키 전달이 불가해 쿼리 파라미터로 토큰 전달
@@ -59,7 +61,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       });
       client.disconnect();
       // 서버에 로그남기는 용도
-      Logger.error(`웹소켓 연결에 실패했습니다. ${error}`);
+      this.logger.error(`웹소켓 연결에 실패했습니다. ${error}`);
     }
   }
 

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -59,9 +59,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       });
       client.disconnect();
       // 서버에 로그남기는 용도
-      throw new WsException({
-        message: `웹소켓 연결에 실패했습니다. ${error.message}`,
-      });
+      console.log(`웹소켓 연결에 실패했습니다. ${error.message}`);
     }
   }
 

--- a/src/chat/filters/ws-exception.filter.ts
+++ b/src/chat/filters/ws-exception.filter.ts
@@ -20,6 +20,6 @@ export class WsExceptionFilter implements ExceptionFilter {
     // 클라이언트에게 에러 이벤트 전송
     client.emit('error', errorResponse);
     // 서버 콘솔에 로그 남기기
-    this.logger.error('Websocket 에러 발생:', errorResponse);
+    this.logger.error(exception);
   }
 }

--- a/src/chat/filters/ws-exception.filter.ts
+++ b/src/chat/filters/ws-exception.filter.ts
@@ -1,9 +1,11 @@
-import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
+import { ArgumentsHost, Catch, ExceptionFilter, Logger } from '@nestjs/common';
 import { WsException } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
 
 @Catch(WsException)
 export class WsExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(WsExceptionFilter.name);
+
   catch(exception: WsException, host: ArgumentsHost) {
     const client = host.switchToWs().getClient<Socket>();
     const error = exception.getError();
@@ -17,5 +19,7 @@ export class WsExceptionFilter implements ExceptionFilter {
 
     // 클라이언트에게 에러 이벤트 전송
     client.emit('error', errorResponse);
+    // 서버 콘솔에 로그 남기기
+    this.logger.error('Websocket 에러 발생:', errorResponse);
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#47 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- handleConnection에서는 exception filter가 적용이 되지 않아 exception을 throw하면 서버가 중지되는 현상을 피하기 위해 exception을 throw하지 않게 변경
  - 관련 [stackoverflow 글](https://stackoverflow.com/questions/78351390/exception-filter-nestjs-not-working-on-my-websocket-gateway), [nestjs 이슈](https://github.com/nestjs/nest/issues/336#issuecomment-355300176)   
- 디버깅을 위해 Logger를 적용해 웹소켓 에러 발생 시 서버측에도 정보를 남기게 함

### 스크린샷 (선택)

웹소켓 전반에서 WsException으로 던진 에러는 클라이언트뿐만 아니라 서버단에도 기록됨
<img width="617" alt="image" src="https://github.com/user-attachments/assets/09dccb8c-ee02-4d9b-ad27-15273098e4d6" />
![image](https://github.com/user-attachments/assets/84dc6cb6-6b01-42a8-9a6b-90c95230865c)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
