### PR TITLE
Fix/websocket gateway integration

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -4,6 +4,7 @@ import {
   DefaultValuePipe,
   Delete,
   Get,
+  NotFoundException,
   Param,
   ParseIntPipe,
   Post,
@@ -72,7 +73,6 @@ export class ChatController {
     description:
       '해당 UUID의 메세지 이전부터 불러옵니다. 값이 없을 시 가장 최근 메세지부터 불러옵니다.',
     required: false,
-    example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiQuery({
     name: 'take',
@@ -88,27 +88,23 @@ export class ChatController {
     return this.chatService.getMessagesByCursor(roomUuid, before, take);
   }
 
-  @Put(':roomUuid/:messageUuid')
+  @Put(':chatUuid')
   @ApiOperation({
-    summary: '채팅 메세지를 수정합니다.',
+    summary: '[웹소켓 통합 버전-개발 중] 채팅 메세지를 수정합니다.',
   })
   @ApiResponse({
     status: 200,
-    description: '수정된 메세지를 반환합니다.',
+    description:
+      '수정된 메세지를 반환합니다. 웹소켓의 `updatedMessage` 이벤트를 통해 수정된 메세지 정보를 전파합니다.',
+    type: Chat,
   })
   @ApiResponse({
     status: 403,
     description: '메세지 전송자가 아닙니다.',
   })
   @ApiParam({
-    name: 'messageUuid',
+    name: 'chatUuid',
     description: '수정할 메세지의 UUID',
-    required: true,
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
-  @ApiParam({
-    name: 'roomUuid',
-    description: '수정할 메세지가 속한 방의 UUID',
     required: true,
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
@@ -122,45 +118,43 @@ export class ChatController {
   })
   @UseGuards(ChatSenderGuard)
   async updateMessage(
-    @Param('roomUuid') roomUuid: string,
-    @Param('messageUuid') messageUuid: string,
+    @Param('chatUuid') chatUuid: string,
     @Body() body: { message: string },
   ) {
-    // TODO: 수정 후 emit
-    return this.chatService.updateMessage(roomUuid, messageUuid, body);
+    const updatedChat = await this.chatService.updateMessage(chatUuid, body);
+    if (!updatedChat) {
+      throw new NotFoundException('메세지를 찾을 수 없습니다.');
+    }
+    this.chatGateway.sendUpdatedMessage(updatedChat);
+    return updatedChat;
   }
 
-  @Delete(':roomUuid/:messageUuid')
+  @Delete(':chatUuid')
   @ApiOperation({
-    summary: '채팅 메세지를 삭제합니다.',
+    summary: '[웹소켓 통합 버전-개발 중] 채팅 메세지를 삭제합니다.',
   })
   @ApiResponse({
     status: 200,
-    description: '삭제된 메세지의 UUID를 반환합니다.',
+    description:
+      '삭제된 메세지의 UUID를 반환합니다. 웹소켓의 `deletedMessage` 이벤트를 통해 삭제된 메세지의 UUID를 전파합니다.',
+    example: { uuid: '123e4567-e89b-12d3-a456-426614174000' },
   })
   @ApiResponse({
     status: 403,
     description: '메세지 전송자가 아닙니다.',
   })
   @ApiParam({
-    name: 'roomUuid',
-    description: '삭제할 메세지가 속한 방의 UUID',
-    required: true,
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
-  @ApiParam({
-    name: 'messageUuid',
+    name: 'chatUuid',
     description: '삭제할 메세지의 UUID',
     required: true,
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @UseGuards(ChatSenderGuard)
-  async deleteMessage(
-    @Param('roomUuid') roomUuid: string,
-    @Param('messageUuid') messageUuid: string,
-  ) {
-    // TODO: 삭제 후 emit
-    return this.chatService.deleteMessage(roomUuid, messageUuid);
+  async deleteMessage(@Param('chatUuid') chatUuid: string) {
+    const { roomUuid, deletedChatUuid } =
+      await this.chatService.deleteMessage(chatUuid);
+    this.chatGateway.sendDeletedMessage(roomUuid, deletedChatUuid);
+    return deletedChatUuid;
   }
 
   @Post(':roomUuid')

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -6,8 +6,10 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Post,
   Put,
   Query,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -19,10 +21,14 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 
+import { JwtPayload } from 'src/auth/strategies/jwt.payload';
+
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ChatService } from './chat.service';
 import { Chat } from './entities/chat.entity';
 import { ChatSenderGuard } from './guards/chat-sender.guard';
+import { ChatGateway } from './chat.gateway';
+import { ChatMessageType } from './entities/chat.meta';
 @ApiCookieAuth()
 @UseGuards(JwtAuthGuard)
 @ApiResponse({
@@ -36,7 +42,10 @@ import { ChatSenderGuard } from './guards/chat-sender.guard';
 @Controller('chat')
 // TODO: 덕지덕지 데코레이터 정리하기
 export class ChatController {
-  constructor(private readonly chatService: ChatService) {}
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly chatGateway: ChatGateway,
+  ) {}
 
   @Get(':roomUuid')
   @ApiOperation({
@@ -117,6 +126,7 @@ export class ChatController {
     @Param('messageUuid') messageUuid: string,
     @Body() body: { message: string },
   ) {
+    // TODO: 수정 후 emit
     return this.chatService.updateMessage(roomUuid, messageUuid, body);
   }
 
@@ -149,6 +159,47 @@ export class ChatController {
     @Param('roomUuid') roomUuid: string,
     @Param('messageUuid') messageUuid: string,
   ) {
+    // TODO: 삭제 후 emit
     return this.chatService.deleteMessage(roomUuid, messageUuid);
+  }
+
+  @Post(':roomUuid')
+  @ApiOperation({
+    summary: '[웹소켓 통합 버전-개발 중] 방에 채팅을 전송합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      '생성된 메세지를 반환합니다. 채팅 메세지 생성 후 방 전체에 메시지와 푸시 알림을 전송합니다.',
+    type: Chat,
+  })
+  @ApiParam({
+    name: 'roomUuid',
+    description: '생성할 메세지가 속한 방의 UUID',
+    required: true,
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+      },
+    },
+  })
+  async create(
+    @Param('roomUuid') roomUuid: string,
+    @Body() body: { message: string },
+    @Req() req,
+  ) {
+    const user = req.user as JwtPayload;
+    const chat = await this.chatService.create({
+      roomUuid: roomUuid,
+      senderUuid: user.uuid,
+      message: body.message,
+      messageType: ChatMessageType.TEXT,
+    });
+    this.chatGateway.sendMessage(roomUuid, chat);
+    return chat;
   }
 }

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -162,7 +162,7 @@ export class ChatController {
     summary: '[웹소켓 통합 버전-개발 중] 방에 채팅을 전송합니다.',
   })
   @ApiResponse({
-    status: 200,
+    status: 201,
     description:
       '생성된 메세지를 반환합니다. 채팅 메세지 생성 후 방 전체에 메시지와 푸시 알림을 전송합니다.',
     type: Chat,

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
@@ -14,12 +14,12 @@ import { ChatController } from './chat.controller';
   imports: [
     JwtModule,
     TypeOrmModule.forFeature([Chat]),
-    RoomModule,
+    forwardRef(() => RoomModule),
     UserModule,
     FcmModule,
   ],
   controllers: [ChatController],
   providers: [ChatGateway, ChatService],
-  exports: [ChatService],
+  exports: [ChatService, ChatGateway],
 })
 export class ChatModule {}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -86,13 +86,9 @@ export class ChatService {
     });
   }
 
-  async updateMessage(
-    roomUuid: string,
-    messageUuid: string,
-    body: { message: string },
-  ) {
+  async updateMessage(messageUuid: string, body: { message: string }) {
     const chat = await this.chatRepo.findOne({
-      where: { uuid: messageUuid, roomUuid: roomUuid },
+      where: { uuid: messageUuid },
     });
     if (!chat) {
       throw new NotFoundException('메세지를 찾을 수 없습니다.');
@@ -104,14 +100,14 @@ export class ChatService {
     });
   }
 
-  async deleteMessage(roomUuid: string, messageUuid: string) {
-    const message = await this.chatRepo.findOne({
-      where: { uuid: messageUuid, roomUuid: roomUuid },
+  async deleteMessage(messageUuid: string) {
+    const chat = await this.chatRepo.findOne({
+      where: { uuid: messageUuid },
     });
-    if (!message) {
+    if (!chat) {
       throw new NotFoundException('메세지를 찾을 수 없습니다.');
     }
-    await this.chatRepo.delete(message.id);
-    return messageUuid;
+    await this.chatRepo.delete(chat.id);
+    return { roomUuid: chat.roomUuid, deletedChatUuid: chat.uuid };
   }
 }

--- a/src/chat/guards/chat-sender.guard.ts
+++ b/src/chat/guards/chat-sender.guard.ts
@@ -14,9 +14,9 @@ export class ChatSenderGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
     const userUuid = request.user.uuid;
-    const messageUuid = request.params.messageUuid;
+    const chatUuid = request.params.chatUuid;
 
-    const chat = await this.chatService.findOne(messageUuid);
+    const chat = await this.chatService.findOne(chatUuid);
     if (chat.senderUuid !== userUuid) {
       throw new ForbiddenException('메세지 전송자가 아닙니다.');
     }

--- a/src/room/dto/room-user-with-nickname.dto.ts
+++ b/src/room/dto/room-user-with-nickname.dto.ts
@@ -7,13 +7,10 @@ import { Room } from '../entities/room.entity';
 
 // TODO: Swagger 문서화 간편하게 하는 개선방안 필요
 export class RoomUserWithNicknameDto extends PickType(RoomUser, [
-  'id',
   'userUuid',
   'roomUuid',
   'status',
   'isPaid',
-  'createdAt',
-  'updatedAt',
 ]) {
   @ApiProperty({ nullable: false })
   nickname: string;
@@ -32,8 +29,6 @@ export class RoomWithUsersDto extends PickType(Room, [
   'description',
   'payerUuid',
   'payAmount',
-  'createdAt',
-  'updatedAt',
 ]) {
   @ApiProperty({
     type: [RoomUserWithNicknameDto],

--- a/src/room/entities/room.user.entity.ts
+++ b/src/room/entities/room.user.entity.ts
@@ -26,6 +26,7 @@ export class RoomUser extends Base {
   roomUuid: string;
 
   @Column({ nullable: false, default: RoomUserStatus.JOINED })
+  @ApiProperty({ example: RoomUserStatus.JOINED })
   status: RoomUserStatus;
 
   @Column({ nullable: false, default: false })

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -471,7 +471,7 @@ export class RoomController {
     summary: '카풀 방의 정산 정보를 등록합니다.',
   })
   @ApiResponse({
-    status: 200,
+    status: 201,
     description: '정산 정보를 등록합니다.',
   })
   @ApiResponse({
@@ -492,7 +492,7 @@ export class RoomController {
     summary: '[웹소켓 통합 버전-개발 중] 카풀 방의 정산 정보를 등록합니다.',
   })
   @ApiResponse({
-    status: 200,
+    status: 201,
     description: '정산 정보를 등록합니다. 방에 정산 메세지를 전송합니다.',
   })
   @ApiResponse({

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -633,14 +633,12 @@ export class RoomController {
   })
   async updateIsPaid(
     @Param('uuid') uuid: string,
-    @Param('userUuid') userUuid: string,
     @Req() req,
     @Body() body: { isPaid: boolean },
   ) {
     const user = req.user as JwtPayload;
     return await this.roomService.updateRoomUserIsPaid(
       uuid,
-      userUuid,
       user.uuid,
       body.isPaid,
     );

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -602,7 +602,7 @@ export class RoomController {
     return await this.roomService.cancelSettlement(uuid, user.uuid);
   }
 
-  @Patch(':uuid/:userUuid/pay')
+  @Patch(':uuid/pay')
   @ApiOperation({
     summary: '카풀 방에 대한 유저의 정산 여부를 수정합니다.',
   })

--- a/src/room/room.module.ts
+++ b/src/room/room.module.ts
@@ -1,14 +1,19 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Room } from 'src/room/entities/room.entity';
 import { RoomUser } from 'src/room/entities/room.user.entity';
 import { UserModule } from 'src/user/user.module';
+import { ChatModule } from 'src/chat/chat.module';
 
 import { RoomService } from './room.service';
 import { RoomController } from './room.controller';
 @Module({
-  imports: [TypeOrmModule.forFeature([Room, RoomUser]), UserModule],
+  imports: [
+    TypeOrmModule.forFeature([Room, RoomUser]),
+    UserModule,
+    forwardRef(() => ChatModule),
+  ],
   controllers: [RoomController],
   providers: [RoomService],
   exports: [RoomService],

--- a/src/room/room.module.ts
+++ b/src/room/room.module.ts
@@ -5,6 +5,7 @@ import { Room } from 'src/room/entities/room.entity';
 import { RoomUser } from 'src/room/entities/room.user.entity';
 import { UserModule } from 'src/user/user.module';
 import { ChatModule } from 'src/chat/chat.module';
+import { FcmModule } from 'src/fcm/fcm.module';
 
 import { RoomService } from './room.service';
 import { RoomController } from './room.controller';
@@ -13,6 +14,7 @@ import { RoomController } from './room.controller';
     TypeOrmModule.forFeature([Room, RoomUser]),
     UserModule,
     forwardRef(() => ChatModule),
+    FcmModule,
   ],
   controllers: [RoomController],
   providers: [RoomService],

--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -656,7 +656,7 @@ export class RoomService {
       throw new BadRequestException('방이 존재하지 않습니다.');
     }
 
-    if (room.status != RoomStatus.IN_SETTLEMENT) {
+    if (room.status != RoomStatus.IN_SETTLEMENT || room.payerUuid == null) {
       throw new BadRequestException('정산이 진행되고 있지 않습니다.');
     }
 
@@ -668,13 +668,13 @@ export class RoomService {
       throw new BadRequestException('방에 가입되어 있지 않습니다.');
     }
 
-    // TODO: 정산자에게 정산 완료 알림 기능 추가
-
     await this.roomUserRepo.update({ roomUuid, userUuid }, { isPaid });
 
-    return await this.roomUserRepo.findOne({
+    const result = await this.roomUserRepo.findOne({
       where: { roomUuid, userUuid },
     });
+
+    return { payerUuid: room.payerUuid, roomUser: result };
   }
 
   async completeRoom(uuid: string, userUuid: string, userType: UserType) {

--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -649,29 +649,22 @@ export class RoomService {
   async updateRoomUserIsPaid(
     roomUuid: string,
     userUuid: string,
-    requestUserUuid: string,
     isPaid: boolean,
   ) {
-    if (requestUserUuid != userUuid) {
-      throw new UnauthorizedException(
-        '정산자가 아니므로 정산 정보를 수정할 수 없습니다.',
-      );
-    }
-
     const room = await this.findOne(roomUuid);
     if (!room) {
       throw new BadRequestException('방이 존재하지 않습니다.');
+    }
+
+    if (room.status != RoomStatus.IN_SETTLEMENT) {
+      throw new BadRequestException('정산이 진행되고 있지 않습니다.');
     }
 
     const roomUser = await this.roomUserRepo.findOne({
       where: { roomUuid, userUuid },
     });
 
-    if (!roomUser) {
-      throw new BadRequestException('방에 가입되어 있지 않습니다.');
-    }
-
-    if (roomUser.status != RoomUserStatus.JOINED) {
+    if (!roomUser || roomUser.status != RoomUserStatus.JOINED) {
       throw new BadRequestException('방에 가입되어 있지 않습니다.');
     }
 

--- a/src/user/entities/nickname.entity.ts
+++ b/src/user/entities/nickname.entity.ts
@@ -1,19 +1,18 @@
 import {
   Column,
-  CreateDateColumn,
   Entity,
   JoinColumn,
   OneToOne,
   PrimaryGeneratedColumn,
-  UpdateDateColumn,
 } from 'typeorm';
 import { ApiHideProperty } from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
 
-import { User } from './user.entity';
+import { Base } from 'src/common/base.entity';
 
+import { User } from './user.entity';
 @Entity('nickname')
-export class Nickname {
+export class Nickname extends Base {
   @PrimaryGeneratedColumn()
   @ApiHideProperty()
   @Exclude()
@@ -24,14 +23,6 @@ export class Nickname {
 
   @Column({ type: 'varchar', length: 20, nullable: false })
   nickname: string;
-
-  @CreateDateColumn()
-  @ApiHideProperty()
-  createdAt: Date;
-
-  @UpdateDateColumn()
-  @ApiHideProperty()
-  updatedAt: Date;
 
   @OneToOne(() => User, (user) => user.nickname, {
     onDelete: 'CASCADE',

--- a/websocket-api.md
+++ b/websocket-api.md
@@ -4,23 +4,21 @@
 - local server URL: `ws://localhost:4100`
 - dev server URL: `wss://api.paxi-dev.popo.poapper.club?Authentication=[토큰값]`
 - 인증: Cookie에 'Authentication' 토큰 필요
-  - ~~토큰이 없거나 유효하지 않은 경우 연결이 거부됨~~
-  - ~~**React Native에서 Websocket 연결 시 쿠키를 사용할 수 없다면 다른 인증 방법을 사용해야 함 (TODO)**~~
+  - 토큰이 없거나 유효하지 않은 경우 연결이 거부됨
   - React Native에서 웹소켓 연결 시 쿠키를 보내지 못한므로 `Authentication` 토큰 값을 쿼리 파라미터에 실어 보냄
 
-## 이벤트
+## Listening 이벤트
 
-### 0. 메세지 받기
-- `newMessage`를 listening 해야 함
-- 이벤트로 채팅 혹은 공지 등 새로운 메세지를 받을 수 있음
-- SenderUuid: null인 경우는 시스템 메세지임
-  - 현재 joinRoom(유저 첫 입장일 때만), leaveRoom 이벤트에서 시스템 메세지를 보내고 있음(해당 게이트웨이를 controller로 병합 예정)
+### 1. 메세지 받기
+- `newMessage`를 통해 채팅 혹은 공지 등 새로운 메세지를 받을 수 있음
+  - 유저의 방 입장, 퇴장, 강퇴, 정산 요청, 정산 완료 등 방의 상태 변경 시 시스템 메세지를 받을 수 있음
+- `SenderUuid: null`인 경우는 시스템 메세지이므로 프론트에서 따로 처리 필요
 - 메시지 예시:
 ```json
 {
   "uuid": "12e18adf-9a25-42e7-b0b9-88d222542c5e",
   "roomUuid": "45281c1e-61e5-4628-8821-6e0cb0940fd3",
-  "senderUuid": null,
+  "senderUuid": null, // 시스템 메세지
   "message": "나태양 님이 방에 참여했습니다.",
   "messageType": "TEXT",
   "createdAt": "2025-05-10T11:27:41.045Z",
@@ -28,20 +26,45 @@
 }
 ```
 
-### 1. 연결 (Connection)
-- 자동으로 처리됨
-- 연결 시 인증 토큰 검증
-- 연결 성공 시:
-  - `client.data.user`: JWT Payload(유저 uuid, usertype, email, 유저이름) 정보 저장
-  - `client.data.rooms`: 참여 중인 방 UUID Set 초기화
+### 2. 메세지 수정
+- `updatedMessage`를 통해 수정된 메세지를 받을 수 있음
+- `PUT /chat/:chatUuid` 엔드포인트에서 사용됨
+- 현재 채팅방에 있는 유저(=소켓에 연결되어 있는 유저)들의 채팅 메세지를 실시간으로 수정하기 위해 사용
+- 응답 메세지 예시:
+```json
+{
+  "uuid": "12e18adf-9a25-42e7-b0b9-88d222542c5e",
+  "roomUuid": "45281c1e-61e5-4628-8821-6e0cb0940fd3",
+  "senderUuid": "12e18adf-9a25-42e7-b0b9-88d222542c5e", // 유저 메세지
+  "message": "수정된 메세지.",
+  "messageType": "TEXT",
+  "createdAt": "2025-05-10T11:27:41.045Z",
+  "updatedAt": "2025-05-10T11:27:41.045Z"
+}
+```
 
-### 2. 연결 해제 (Disconnection)
+### 3. 메세지 삭제
+- `deletedMessage`를 통해 **삭제된 메세지의 UUID**를 받을 수 있음
+- `DELETE /chat/:chatUuid` 엔드포인트에서 사용됨
+- 현재 채팅방에 있는 유저(=소켓에 연결되어 있는 유저)들의 채팅 메세지를 실시간으로 삭제하기 위해 사용
+- 응답 메세지 예시:
+```json
+{
+  "uuid": "12e18adf-9a25-42e7-b0b9-88d222542c5e"
+}
+```
+
+## 이벤트 발생
+
+### 1. 연결 해제 (Disconnection)
 - 자동으로 처리됨
 - 연결 해제 시:
-  - `client.data.user` 삭제
-  - `client.data.rooms` 삭제
+  - 유저의 소켓 데이터를 삭제해 실시간 채팅 기능 중단
+  - JWT Payload 정보가 담긴 `client.data.user` 삭제
 
-### 3. 채팅방 참여
+### **NOTE: 아래 채팅방 참여, 메세지 전송, 방 나가기 이벤트들은 웹소켓을 컨트롤러에 병합하는 작업이 완료되면 사라질 예정**
+
+### 2. *채팅방 참여(삭제 예정)*
 - 이벤트명: `joinRoom`
 - 요청 데이터:
 ```json
@@ -59,7 +82,7 @@
      - 메시지 읽음 처리 (TODO)
 - **주의:** 방에 실제로 참여하는 것은 아니므로 */room/join/:uuid* 도 함께 호출해야 함
 
-### 4. 메시지 전송
+### 3. *메시지 전송(삭제 예정)*
 - 이벤트명: `sendMessage`
 - 요청 데이터:
 ```json
@@ -74,7 +97,7 @@
   2. 메시지 저장
   3. 본인과 다른 방 유저들에게 메시지 전송
 
-### 5. 방 나가기
+### 4. *방 나가기(삭제 예정)*
 - 이벤트명: `leaveRoom`
 - 요청 데이터: `string` (roomUuid)
 - 응답: `newMessage` 이벤트로 시스템 메시지 수신
@@ -93,5 +116,5 @@
   - 방 참여/나가기 실패
 
 ## TODO
-- 소켓이 끊어지고 다시 연결될 때 소켓 복원 기능
+- ~~소켓이 끊어지고 다시 연결될 때 소켓 복원 기능~~ 필요하지 않음
 - 메시지 읽음 처리 기능


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#57 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

chatGateway를 chatController와 roomController에서 service처럼 사용할 수 있게끔 이슈에 나열된 작업들을 진행했습니다.

변경한 모든 엔드포인트는 기존 것을 유지한 채 새로운 엔드포인트로 작성했습니다. Swagger 상의 엔드포인트에서 실행 시 메세지가 emit/app push 되는 엔드포인트는 따로 [웹소켓 통합 버전-개발 중]이라는 문구를 달아 뒀습니다. 해당 엔드포인트 작동이 확인되면 기존 것을 삭제하면 될 것 같아요. 

다른 변경 사항
- 메세지를 전파하는 모든 새로운 엔드포인트는 postman에서 서로 다른 유저 웹소켓 접속 후 메세지가 잘 수신되는지 확인했음
- 기존 `PUT, DELETE /chat/{roomUuid}/{chatUuid}` 엔드포인트에서 불필요한 {roomUuid} 경로 파라미터 제거
  - 해당 엔드포인트의 기존 경로 파라미터인 {messageUuid}를 엔티티에 맞게 {chatUuid}로 변경함
- figma에 따르면 참여자가 자신의 정산 유/무를 수정할 수 있게 되어있음. 하지만, 이를 수행하는 기존 `PATCH /room/{uuid}/pay`는 정산자가 참여자의 정산 유/무를 수정하도록 되어 있어, 기획을 따르도록 로직 변경
- `updatedMessage`및 `deletedMessage` 웹소켓 이벤트를 추가해 메세지 수정/삭제 시 프론트로 알리는 로직을 추가함
- 변경 사항에 맞게 Websocket api docs를 수정함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
