### PR TITLE
Feat/update room websocket event

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "format": "prettier --w **/*.ts",
     "format:check": "prettier --c **/*.ts",
     "lint": "eslint --fix . --ext .ts",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test": "NODE_ENV=test jest",
+    "test:watch": "NODE_ENV=test jest --watch",
+    "test:cov": "NODE_ENV=test jest --coverage",
+    "test:debug": "NODE_ENV=test node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "NODE_ENV=test jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.20",
@@ -83,6 +83,7 @@
     "typescript-eslint": "^8.20.0"
   },
   "jest": {
+    "watchman": false,
     "moduleFileExtensions": [
       "js",
       "json",

--- a/src/room/dto/create-room.dto.ts
+++ b/src/room/dto/create-room.dto.ts
@@ -6,7 +6,7 @@ import {
   IsOptional,
   IsString,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 
 export class CreateRoomDto {
   @IsString()
@@ -14,6 +14,7 @@ export class CreateRoomDto {
   @ApiProperty({
     example: '캐리어 두 개 있습니다',
   })
+  @Expose()
   readonly description?: string;
 
   @IsString()
@@ -21,6 +22,7 @@ export class CreateRoomDto {
   @ApiProperty({
     example: '포항역 가는 택시 같이 타요 🚕',
   })
+  @Expose()
   readonly title: string;
 
   @Type(() => Date)
@@ -29,6 +31,7 @@ export class CreateRoomDto {
   @ApiProperty({
     example: '2026-01-01 12:00:00',
   })
+  @Expose()
   readonly departureTime: Date;
 
   @IsString()
@@ -36,6 +39,7 @@ export class CreateRoomDto {
   @ApiProperty({
     example: '지곡회관',
   })
+  @Expose()
   readonly departureLocation: string;
 
   @IsString()
@@ -43,6 +47,7 @@ export class CreateRoomDto {
   @ApiProperty({
     example: '포항역',
   })
+  @Expose()
   readonly destinationLocation: string;
 
   @IsNumber()
@@ -50,5 +55,6 @@ export class CreateRoomDto {
   @ApiProperty({
     example: 4,
   })
+  @Expose()
   readonly maxParticipant: number;
 }

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -146,6 +146,21 @@ export class RoomController {
 
     const roomDiff = this.roomService.getRoomDiff(originalRoom, updatedRoom);
 
+    // 사용성을 위해 수정된 내용이 없으면 에러 없이 방 정보를 반환
+    if (Object.keys(roomDiff).length === 0) {
+      return updatedRoom;
+    }
+
+    const message = this.roomService.generateRoomUpdateMessage(
+      originalRoom,
+      roomDiff,
+    );
+    const chat = await this.chatService.create({
+      roomUuid: uuid,
+      message: message,
+      messageType: ChatMessageType.TEXT,
+    });
+    this.chatGateway.sendMessage(uuid, chat);
     this.chatGateway.sendUpdatedRoom(uuid, updatedRoom, roomDiff);
 
     return updatedRoom;

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -137,7 +137,18 @@ export class RoomController {
     @User() user: JwtPayload,
     @Body() updateRoomDto: UpdateRoomDto,
   ) {
-    return await this.roomService.update(uuid, updateRoomDto, user);
+    const originalRoom = await this.roomService.findOne(uuid);
+    const updatedRoom = await this.roomService.update(
+      uuid,
+      updateRoomDto,
+      user,
+    );
+
+    const roomDiff = this.roomService.getRoomDiff(originalRoom, updatedRoom);
+
+    this.chatGateway.sendUpdatedRoom(uuid, updatedRoom, roomDiff);
+
+    return updatedRoom;
   }
 
   @Delete(':uuid')

--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -891,4 +891,57 @@ export class RoomService {
     }
     return diff;
   }
+
+  generateRoomUpdateMessage(
+    originalRoom: Room,
+    roomDiff: Record<string, any>,
+  ): string {
+    const changes: string[] = [];
+
+    if (roomDiff.title) {
+      changes.push(`제목: ${originalRoom.title} → ${roomDiff.title}`);
+    }
+    if (
+      roomDiff.description !== undefined &&
+      originalRoom.description !== roomDiff.description
+    ) {
+      const originalDesc = originalRoom.description || '(설명 없음)';
+      const newDesc = roomDiff.description || '(설명 없음)';
+      changes.push(`설명: ${originalDesc} → ${newDesc}`);
+    }
+    if (roomDiff.maxParticipant) {
+      changes.push(
+        `최대 인원: ${originalRoom.maxParticipant}명 → ${roomDiff.maxParticipant}명`,
+      );
+    }
+    if (roomDiff.departureLocation) {
+      changes.push(
+        `출발지: ${originalRoom.departureLocation} → ${roomDiff.departureLocation}`,
+      );
+    }
+    if (roomDiff.destinationLocation) {
+      changes.push(
+        `도착지: ${originalRoom.destinationLocation} → ${roomDiff.destinationLocation}`,
+      );
+    }
+    if (roomDiff.departureTime) {
+      const originalTime = originalRoom.departureTime.toLocaleString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      const newTime = new Date(roomDiff.departureTime).toLocaleString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      changes.push(`출발 시간: ${originalTime} → ${newTime}`);
+    }
+
+    return `방 정보가 수정되었습니다.\n${changes.join('\n')}`;
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

> 방 정보 업데이트 시 정보가 업데이트 되었다는 채팅방에 접속해있는 유저들에게 변경 알림 및 변경 정보 메세지 전송
변경된 방 정보를 `updatedRoom`으로 websocket event를 전송하여 채팅방에 있는 유저들이 실시간으로 변경된 방 정보를 알 수 있게 프론트가 실시간 수정을 가능케 함.

### 스크린샷 (선택)
`newMessage` websocket event
<img width="875" alt="image" src="https://github.com/user-attachments/assets/dcff4a8e-037b-4b02-b79b-e2956258dd44" />

`updatedRoom` websocket event
<img width="474" alt="image" src="https://github.com/user-attachments/assets/e0d489c6-7ee8-4d2e-807e-849e3f9dba9b" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
