### PR TITLE
Fix: Filter out deleted rooms to client side

### DIFF
--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -122,6 +122,7 @@ export class RoomService {
     const rooms: Room[] = await this.roomRepo.find({
       where: {
         room_users: { userUuid: userUuid },
+        status: Not(RoomStatus.DELETED),
       },
       select: {
         room_users: {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) 없음

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

`GET /room/my`에서 삭제된 방 정보도 클라이언트로 내려주고 있던 문제 해결

로컬 테스트 완료

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
