### PR TITLE
Fix: Add timezone property

### DIFF
--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -945,6 +945,18 @@ export class RoomService {
     return diff;
   }
 
+  private formatKst(date: Date | string): string {
+    const target = typeof date === 'string' ? new Date(date) : date;
+    return target.toLocaleString('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
   generateRoomUpdateMessage(
     originalRoom: Room,
     roomDiff: Record<string, any>,
@@ -978,21 +990,9 @@ export class RoomService {
       );
     }
     if (roomDiff.departureTime) {
-      const originalTime = originalRoom.departureTime.toLocaleString('ko-KR', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      });
-      const newTime = new Date(roomDiff.departureTime).toLocaleString('ko-KR', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      });
-      changes.push(`출발 시간: ${originalTime} → ${newTime}`);
+      const originalTime = this.formatKst(originalRoom.departureTime);
+      const newTime = this.formatKst(roomDiff.departureTime);
+      changes.push(`출발 시각: ${originalTime} → ${newTime}`);
     }
 
     return `방 정보가 수정되었습니다.\n${changes.join('\n')}`;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

내부 QA에서 나왔던 거
방 정보 출발 시각을 수정 시 수정한 시각이 KST가 아닌 UTC로 보이는 문제를 수정

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

수정 시 출발 시각 변경 값을 KST로 변환해 내려줌
알아둬야 할 것:
- 기존에 KST로 내려주다 이번에 UTC로 잘못 내려준 것이 아님, **KST가 아니라 애초에 서로 UTC로 통신하고 있었음**
- 그러면 왜 문제가 되었냐?
  - 프론트에서 방 정보 수정 시 받는 메세지에 시각 처리를 하지 않음: 시스템 메세지라 메세지 자체를 문자열로 보여주고 있었음
- 프론트에서 바꿀까, 백에서 바꿀까 고민하다가 프론트에서는 공수가 좀 들 것같아 걍 백에서 KST로 변환해 내려주기로 함
- 프론트에서 moment() 를 쓸 때 암시적으로 local time zone을 반영해 시각 변환이 일어나고 있다는 것을 인지하자

### ✅ 테스트 여부 체크

- [x] dev환경에서 기능이 잘 작동하는지 테스트를 진행했습니다
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/4af79ada-1a56-48aa-95a0-2469ba69754f" />
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/194a8344-2915-474d-b5a5-f1b6935328a1" />

- [ ] 테스트 코드를 작성했습니다

### 🖥️ 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
