### PR TITLE
Fix/chat authorization

### DIFF
--- a/src/chat/chat.integration.spec.ts
+++ b/src/chat/chat.integration.spec.ts
@@ -267,78 +267,6 @@ describe('ChatModule - Integration Test', () => {
     });
   });
 
-  describe('getAllMessages', () => {
-    let testRoom: any;
-
-    beforeEach(async () => {
-      testRoom = await roomService.create(testUtils.getTestUser().uuid, {
-        description: '테스트 방입니다',
-        title: '테스트 방',
-        departureTime: new Date(Date.now() + 1000 * 60 * 60 * 24),
-        departureLocation: '출발지',
-        destinationLocation: '도착지',
-        maxParticipant: 4,
-      });
-
-      // 여러 메시지 생성
-      for (let i = 1; i <= 10; i++) {
-        await chatService.create(
-          {
-            roomUuid: testRoom.uuid,
-            senderUuid: testUtils.getTestUser().uuid,
-            message: `메시지 ${i}`,
-            messageType: ChatMessageType.TEXT,
-          },
-          '테스트_닉네임',
-        );
-      }
-    });
-
-    it('should get messages with pagination', async () => {
-      const result = await chatService.getAllMessages(testRoom.uuid, 5, 0);
-
-      expect(result).toHaveLength(5);
-      for (let i = 0; i < 5; i++) {
-        expect(result[i].senderNickname).toBe('테스트_닉네임');
-        expect(result[i].senderUuid).toBe(testUtils.getTestUser().uuid);
-        expect(result[i].message).toBe(`메시지 ${i + 1}`);
-        expect(result[i].messageType).toBe(ChatMessageType.TEXT);
-      }
-    });
-
-    it('should get messages with skip', async () => {
-      const skipLength = 5;
-      const result = await chatService.getAllMessages(
-        testRoom.uuid,
-        5,
-        skipLength,
-      );
-
-      expect(result).toHaveLength(5);
-      for (let i = 0; i < 5; i++) {
-        expect(result[i].senderNickname).toBe('테스트_닉네임');
-        expect(result[i].senderUuid).toBe(testUtils.getTestUser().uuid);
-        expect(result[i].message).toBe(`메시지 ${i + skipLength + 1}`);
-        expect(result[i].messageType).toBe(ChatMessageType.TEXT);
-      }
-    });
-
-    it('should return empty array when no messages exist', async () => {
-      const emptyRoom = await roomService.create(testUtils.getTestUser().uuid, {
-        description: '빈 방',
-        title: '빈 방',
-        departureTime: new Date(Date.now() + 1000 * 60 * 60 * 24),
-        departureLocation: '출발지',
-        destinationLocation: '도착지',
-        maxParticipant: 4,
-      });
-
-      const result = await chatService.getAllMessages(emptyRoom.uuid, 10, 0);
-
-      expect(result).toHaveLength(0);
-    });
-  });
-
   describe('getMessagesByCursor', () => {
     let testRoom: any;
     let testChats: Chat[];
@@ -370,14 +298,16 @@ describe('ChatModule - Integration Test', () => {
     });
 
     it('should get messages without before parameter (latest messages)', async () => {
+      const before = null;
+      const take = 5;
       const result = await chatController.getMessages(
         testRoom.uuid,
-        null,
-        5,
+        before,
+        take,
         testUtils.getTestUserJwtToken(),
       );
 
-      expect(result).toHaveLength(5);
+      expect(result).toHaveLength(take);
       // 최신 메시지부터 가져와야 함 (ID 내림차순)
       expect(result[0].id).toBeGreaterThan(result[1].id);
     });

--- a/src/chat/chat.integration.spec.ts
+++ b/src/chat/chat.integration.spec.ts
@@ -431,7 +431,10 @@ describe('ChatModule - Integration Test', () => {
           userType: UserType.admin,
         });
 
-        await userService.createNickname(kickedAdmin.uuid, '강퇴된_어드민_1234');
+        await userService.createNickname(
+          kickedAdmin.uuid,
+          '강퇴된_어드민_1234',
+        );
 
         kickedAdminJwtToken = {
           uuid: kickedAdmin.uuid,

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -52,14 +52,6 @@ export class ChatService {
     });
   }
 
-  async getAllMessages(roomUuid: string, take: number, skip: number) {
-    return await this.chatRepo.find({
-      where: { roomUuid },
-      take: take,
-      skip: skip,
-    });
-  }
-
   async getMessagesByCursor(
     roomUuid: string,
     before: string | null,

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -12,10 +12,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { RoomService } from 'src/room/room.service';
 import { UserType } from 'src/user/user.meta';
 import { RoomUser } from 'src/room/entities/room-user.entity';
+import { RoomUserStatus } from 'src/room/entities/room-user.meta';
 
 import { Chat } from './entities/chat.entity';
 import { CreateChatDto } from './dto/create-chat.dto';
-import { RoomUserStatus } from 'src/room/entities/room-user.meta';
 @Injectable()
 export class ChatService {
   constructor(

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -3,7 +3,7 @@ import {
   Inject,
   Injectable,
   NotFoundException,
-  UnauthorizedException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { LessThan, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -70,13 +70,13 @@ export class ChatService {
 
     // 상황 1: 강퇴된 유저는 채팅을 볼 수 없음. Admin이라도 진짜로 강퇴된 유저라면 적용됨
     if (roomUser && roomUser.status === RoomUserStatus.KICKED) {
-      throw new UnauthorizedException('강퇴된 유저는 채팅을 볼 수 없습니다.');
+      throw new ForbiddenException('강퇴된 유저는 채팅을 볼 수 없습니다.');
     }
 
     // 상황 2: Admin이 방에 속한 유저가 아니라면 채팅을 볼 수 없음 -> 관리자 페이지 용도
     if (!roomUser) {
       if (userType !== UserType.admin) {
-        throw new UnauthorizedException(
+        throw new ForbiddenException(
           '채팅을 볼 권한이 없습니다. 관리자 혹은 방에 속한 유저만 가능합니다.',
         );
       }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -15,6 +15,7 @@ import { RoomUser } from 'src/room/entities/room-user.entity';
 
 import { Chat } from './entities/chat.entity';
 import { CreateChatDto } from './dto/create-chat.dto';
+import { RoomUserStatus } from 'src/room/entities/room-user.meta';
 @Injectable()
 export class ChatService {
   constructor(
@@ -71,15 +72,22 @@ export class ChatService {
       throw new NotFoundException('방이 존재하지 않습니다.');
     }
 
-    if (
-      userType !== UserType.admin &&
-      !(await this.roomUserRepo.findOne({
-        where: { roomUuid, userUuid: userUuid },
-      }))
-    ) {
-      throw new UnauthorizedException(
-        '채팅을 볼 권한이 없습니다. 관리자 혹은 방에 속한 유저만 가능합니다.',
-      );
+    const roomUser = await this.roomUserRepo.findOne({
+      where: { roomUuid, userUuid: userUuid },
+    });
+
+    // 상황 1: 강퇴된 유저는 채팅을 볼 수 없음. Admin이라도 진짜로 강퇴된 유저라면 적용됨
+    if (roomUser && roomUser.status === RoomUserStatus.KICKED) {
+      throw new UnauthorizedException('강퇴된 유저는 채팅을 볼 수 없습니다.');
+    }
+
+    // 상황 2: Admin이 방에 속한 유저가 아니라면 채팅을 볼 수 없음 -> 관리자 페이지 용도
+    if (!roomUser) {
+      if (userType !== UserType.admin) {
+        throw new UnauthorizedException(
+          '채팅을 볼 권한이 없습니다. 관리자 혹은 방에 속한 유저만 가능합니다.',
+        );
+      }
     }
 
     const queryBuilder = this.chatRepo


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#127 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

joinRoom은 강퇴된 유저를 정상적으로 막음. 그러나 프론트에서 해당 엔드포인트가 아니라 chat을 읽는 엔드포인트를 불렀고, 여기서는 강퇴 검증 로직이 없어 생기는 문제. 따라서 chat을 불러올 때도 강퇴 여부를 검사함

### ✅ 테스트 여부 체크

- [x] 로컬 환경에서 기능이 잘 작동하는지 테스트를 진행했습니다
- [x] 테스트 코드를 작성했습니다

### 🖥️ 스크린샷 (선택)



## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
