### PR TITLE
Fix: Find DB if there is no nickname in token

### DIFF
--- a/src/room/room.integration.spec.ts
+++ b/src/room/room.integration.spec.ts
@@ -538,7 +538,7 @@ describe('RoomModule - Integration Test', () => {
       const endDate = `${y}-${mStr}-${lastDay}`;
 
       // Room A (ACTIVE)
-      const roomA = await roomService.create(testUtils.getTestUser().uuid, {
+      await roomService.create(testUtils.getTestUser().uuid, {
         description: 'A desc',
         title: 'A 제목',
         departureTime: new Date(Date.now() + 1000 * 60 * 60 * 24 * 1),
@@ -618,7 +618,7 @@ describe('RoomModule - Integration Test', () => {
       expect(monthData).toBeDefined();
       if (!monthData) {
         throw new Error(
-          `Month data not found for key: ${monthKey}. Available keys: ${Object.keys(res.data)}`,
+          `Month data not found for key: ${monthKey}. Available keys: ${Object.keys(res.data).join(', ')}`,
         );
       }
 

--- a/src/room/room.integration.spec.ts
+++ b/src/room/room.integration.spec.ts
@@ -528,13 +528,17 @@ describe('RoomModule - Integration Test', () => {
     it('should return monthly statistics with status and location dictionaries', async () => {
       const now = new Date();
       const y = now.getFullYear();
-      const m = (now.getMonth() + 1).toString().padStart(2, '0');
-      const startDate = `${y}${m}01`;
-      // 임의로 월말을 크게 잡아 다음달 01로 범위를 만들기 위해 31일 지정
-      const endDate = `${y}${m}31`;
+      const m = now.getMonth() + 1;
+      const mStr = m.toString().padStart(2, '0');
+      
+      // 현재 월의 마지막 날 계산
+      const lastDay = new Date(y, m, 0).getDate();
+      
+      const startDate = `${y}-${mStr}-01`;
+      const endDate = `${y}-${mStr}-${lastDay}`;
 
       // Room A (ACTIVE)
-      await roomService.create(testUtils.getTestUser().uuid, {
+      const roomA = await roomService.create(testUtils.getTestUser().uuid, {
         description: 'A desc',
         title: 'A 제목',
         departureTime: new Date(Date.now() + 1000 * 60 * 60 * 24 * 1),
@@ -606,11 +610,14 @@ describe('RoomModule - Integration Test', () => {
         endDate,
       });
       expect(res).toBeDefined();
-      const monthKey = `${y}-${m}`;
+      
+      // 현재 월을 기준으로 monthKey 생성 (두 자리 월 형식으로)
+      const monthKey = `${y}-${mStr}`;
+      
       const monthData = res.data[monthKey];
       expect(monthData).toBeDefined();
       if (!monthData) {
-        throw new Error('Month data not found');
+        throw new Error(`Month data not found for key: ${monthKey}. Available keys: ${Object.keys(res.data)}`);
       }
 
       // statusCounts dictionary

--- a/src/room/room.integration.spec.ts
+++ b/src/room/room.integration.spec.ts
@@ -530,10 +530,10 @@ describe('RoomModule - Integration Test', () => {
       const y = now.getFullYear();
       const m = now.getMonth() + 1;
       const mStr = m.toString().padStart(2, '0');
-      
+
       // 현재 월의 마지막 날 계산
       const lastDay = new Date(y, m, 0).getDate();
-      
+
       const startDate = `${y}-${mStr}-01`;
       const endDate = `${y}-${mStr}-${lastDay}`;
 
@@ -610,14 +610,16 @@ describe('RoomModule - Integration Test', () => {
         endDate,
       });
       expect(res).toBeDefined();
-      
+
       // 현재 월을 기준으로 monthKey 생성 (두 자리 월 형식으로)
       const monthKey = `${y}-${mStr}`;
-      
+
       const monthData = res.data[monthKey];
       expect(monthData).toBeDefined();
       if (!monthData) {
-        throw new Error(`Month data not found for key: ${monthKey}. Available keys: ${Object.keys(res.data)}`);
+        throw new Error(
+          `Month data not found for key: ${monthKey}. Available keys: ${Object.keys(res.data)}`,
+        );
       }
 
       // statusCounts dictionary

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -64,10 +64,15 @@ export class UserController {
       '낮은 확률이지만, 제한 횟수 초과로 랜덤 닉네임을 생성하는 데 실패한 경우',
   })
   async getOnboardingStatus(@User() user: JwtPayload) {
-    if (user.nickname) {
+    // Paxi탭에 들어갈 때 프론트에선 해당 엔드포인트를 호출함. 닉네임을 만든 직후에는 토큰에 닉네임 값이 없으므로 DB에서 조회함
+    const nickname = user.nickname
+      ? user.nickname
+      : (await this.userService.getNickname(user.uuid))?.nickname;
+
+    if (nickname) {
       return {
         onboardingStatus: true,
-        nickname: user.nickname,
+        nickname: nickname,
       };
     }
 

--- a/src/user/user.integration.spec.ts
+++ b/src/user/user.integration.spec.ts
@@ -200,4 +200,106 @@ describe('UserModule - Integration Test', () => {
       ).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('getOnboardingStatus', () => {
+    it('should return onboarding status when nickname exists in JWT token', async () => {
+      // JWT 토큰에 닉네임이 있는 경우
+      const userWithNicknameInToken: JwtPayload = {
+        uuid: testUtils.getTestUser().uuid,
+        email: testUtils.getTestUser().email,
+        name: testUtils.getTestUser().name,
+        nickname: '토큰에_있는_닉네임',
+        userType: UserType.student,
+      };
+
+      const result = await userController.getOnboardingStatus(userWithNicknameInToken);
+
+      expect(result).toEqual({
+        onboardingStatus: true,
+        nickname: '토큰에_있는_닉네임',
+      });
+    });
+
+    it('should return onboarding status when nickname exists in DB but not in JWT token', async () => {
+      // 먼저 DB에 닉네임 생성
+      await userService.createNickname(testUtils.getTestUser().uuid, 'DB에_있는_닉네임');
+
+      // JWT 토큰에는 닉네임이 없는 경우
+      const userWithoutNicknameInToken: JwtPayload = {
+        uuid: testUtils.getTestUser().uuid,
+        email: testUtils.getTestUser().email,
+        name: testUtils.getTestUser().name,
+        nickname: '', // 빈 문자열
+        userType: UserType.student,
+      };
+
+      const result = await userController.getOnboardingStatus(userWithoutNicknameInToken);
+
+      expect(result).toEqual({
+        onboardingStatus: true,
+        nickname: 'DB에_있는_닉네임',
+      });
+    });
+
+    it('should return onboarding status when nickname exists in DB but JWT token nickname is null', async () => {
+      // 먼저 DB에 닉네임 생성
+      await userService.createNickname(testUtils.getTestUser().uuid, 'DB에_있는_닉네임');
+
+      // JWT 토큰에는 닉네임이 null인 경우
+      const userWithNullNicknameInToken: JwtPayload = {
+        uuid: testUtils.getTestUser().uuid,
+        email: testUtils.getTestUser().email,
+        name: testUtils.getTestUser().name,
+        nickname: null as any, // "nickname": null 과 같이 옴, 빈 문자열 x
+        userType: UserType.student,
+      };
+
+      const result = await userController.getOnboardingStatus(userWithNullNicknameInToken);
+
+      expect(result).toEqual({
+        onboardingStatus: true,
+        nickname: 'DB에_있는_닉네임',
+      });
+    });
+
+    it('should return onboarding status false when nickname does not exist in both JWT token and DB', async () => {
+      // JWT 토큰과 DB 모두에 닉네임이 없는 경우
+      const userWithoutNickname: JwtPayload = {
+        uuid: testUtils.getTestUser().uuid,
+        email: testUtils.getTestUser().email,
+        name: testUtils.getTestUser().name,
+        nickname: null as any,
+        userType: UserType.student,
+      };
+
+      const result = await userController.getOnboardingStatus(userWithoutNickname);
+
+      expect(result).toEqual({
+        onboardingStatus: false,
+        nickname: expect.any(String), 
+      });
+      expect(result.nickname).toMatch(/^[가-힣]+_[가-힣]+_\d{4}$/); // 랜덤 닉네임 패턴 확인
+    });
+
+    it('should prioritize JWT token nickname over DB nickname', async () => {
+      // 먼저 DB에 닉네임 생성
+      await userService.createNickname(testUtils.getTestUser().uuid, 'DB에_있는_닉네임');
+
+      // JWT 토큰에도 다른 닉네임이 있는 경우 (토큰이 우선)
+      const userWithDifferentNicknameInToken: JwtPayload = {
+        uuid: testUtils.getTestUser().uuid,
+        email: testUtils.getTestUser().email,
+        name: testUtils.getTestUser().name,
+        nickname: '토큰에_있는_닉네임',
+        userType: UserType.student,
+      };
+
+      const result = await userController.getOnboardingStatus(userWithDifferentNicknameInToken);
+
+      expect(result).toEqual({
+        onboardingStatus: true,
+        nickname: '토큰에_있는_닉네임', // 토큰의 닉네임이 우선
+      });
+    });
+  });
 });

--- a/src/user/user.integration.spec.ts
+++ b/src/user/user.integration.spec.ts
@@ -212,7 +212,9 @@ describe('UserModule - Integration Test', () => {
         userType: UserType.student,
       };
 
-      const result = await userController.getOnboardingStatus(userWithNicknameInToken);
+      const result = await userController.getOnboardingStatus(
+        userWithNicknameInToken,
+      );
 
       expect(result).toEqual({
         onboardingStatus: true,
@@ -222,7 +224,10 @@ describe('UserModule - Integration Test', () => {
 
     it('should return onboarding status when nickname exists in DB but not in JWT token', async () => {
       // 먼저 DB에 닉네임 생성
-      await userService.createNickname(testUtils.getTestUser().uuid, 'DB에_있는_닉네임');
+      await userService.createNickname(
+        testUtils.getTestUser().uuid,
+        'DB에_있는_닉네임',
+      );
 
       // JWT 토큰에는 닉네임이 없는 경우
       const userWithoutNicknameInToken: JwtPayload = {
@@ -233,7 +238,9 @@ describe('UserModule - Integration Test', () => {
         userType: UserType.student,
       };
 
-      const result = await userController.getOnboardingStatus(userWithoutNicknameInToken);
+      const result = await userController.getOnboardingStatus(
+        userWithoutNicknameInToken,
+      );
 
       expect(result).toEqual({
         onboardingStatus: true,
@@ -243,7 +250,10 @@ describe('UserModule - Integration Test', () => {
 
     it('should return onboarding status when nickname exists in DB but JWT token nickname is null', async () => {
       // 먼저 DB에 닉네임 생성
-      await userService.createNickname(testUtils.getTestUser().uuid, 'DB에_있는_닉네임');
+      await userService.createNickname(
+        testUtils.getTestUser().uuid,
+        'DB에_있는_닉네임',
+      );
 
       // JWT 토큰에는 닉네임이 null인 경우
       const userWithNullNicknameInToken: JwtPayload = {
@@ -254,7 +264,9 @@ describe('UserModule - Integration Test', () => {
         userType: UserType.student,
       };
 
-      const result = await userController.getOnboardingStatus(userWithNullNicknameInToken);
+      const result = await userController.getOnboardingStatus(
+        userWithNullNicknameInToken,
+      );
 
       expect(result).toEqual({
         onboardingStatus: true,
@@ -272,18 +284,22 @@ describe('UserModule - Integration Test', () => {
         userType: UserType.student,
       };
 
-      const result = await userController.getOnboardingStatus(userWithoutNickname);
+      const result =
+        await userController.getOnboardingStatus(userWithoutNickname);
 
       expect(result).toEqual({
         onboardingStatus: false,
-        nickname: expect.any(String), 
+        nickname: expect.any(String),
       });
       expect(result.nickname).toMatch(/^[가-힣]+_[가-힣]+_\d{4}$/); // 랜덤 닉네임 패턴 확인
     });
 
     it('should prioritize JWT token nickname over DB nickname', async () => {
       // 먼저 DB에 닉네임 생성
-      await userService.createNickname(testUtils.getTestUser().uuid, 'DB에_있는_닉네임');
+      await userService.createNickname(
+        testUtils.getTestUser().uuid,
+        'DB에_있는_닉네임',
+      );
 
       // JWT 토큰에도 다른 닉네임이 있는 경우 (토큰이 우선)
       const userWithDifferentNicknameInToken: JwtPayload = {
@@ -294,7 +310,9 @@ describe('UserModule - Integration Test', () => {
         userType: UserType.student,
       };
 
-      const result = await userController.getOnboardingStatus(userWithDifferentNicknameInToken);
+      const result = await userController.getOnboardingStatus(
+        userWithDifferentNicknameInToken,
+      );
 
       expect(result).toEqual({
         onboardingStatus: true,


### PR DESCRIPTION
유저가 Paxi탭에 들어갈 때 onboarding 엔드포인트를 호출함으로써 닉네임이 있는지 없는지 판단하므로 여기서 쿠키에 닉네임이 없다면 DB를 까서 실제로 있는지 없는지 확인해야 함

## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

https://github.com/PoApper/popo-mobile/issues/97

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

클라에서는 Paxi탭에 들어갈 때마다 온보딩 화면을 띄울 지 말지를 onboarding 엔드포인트에서 확인함.
여기서는 현재 쿠키 안에 닉네임이 있는지 여부에 따라 판단하는데, 클라가 닉네임을 설정하고 다시 로그인 하지 않은채 해당 엔드포인를 호출한다면 닉네임이 DB에 있더라도 온보딩을 해야 한다고 응답하는 문제가 있음 

### ✅ 테스트 여부 체크

- [x] 로컬 환경에서 기능이 잘 작동하는지 테스트를 진행했습니다
- [x] 테스트 코드를 작성했습니다

### 🖥️ 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
