### PR TITLE
Chore/capitalize typeorm entities

### DIFF
--- a/src/fcm/entities/fcm-key.entity.ts
+++ b/src/fcm/entities/fcm-key.entity.ts
@@ -4,6 +4,7 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Unique,
 } from 'typeorm';
 import { ApiHideProperty } from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
@@ -11,6 +12,7 @@ import { Exclude } from 'class-transformer';
 import { User } from 'src/user/entities/user.entity';
 import { Base } from 'src/common/base.entity';
 @Entity()
+@Unique(['userUuid', 'pushKey'])
 export class FcmKey extends Base {
   @PrimaryGeneratedColumn()
   @ApiHideProperty()
@@ -27,7 +29,7 @@ export class FcmKey extends Base {
    * Database Relation
    */
 
-  @ManyToOne(() => User, (user) => user.push_keys, {
+  @ManyToOne(() => User, (user) => user.pushKeys, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'user_uuid', referencedColumnName: 'uuid' })

--- a/src/room/dto/room-user-with-nickname.dto.spec.ts
+++ b/src/room/dto/room-user-with-nickname.dto.spec.ts
@@ -1,8 +1,12 @@
-import { RoomUserWithNicknameDto, RoomWithUsersDto } from './room-user-with-nickname.dto';
 import { RoomUserStatus } from 'src/room/entities/room-user.meta';
 import { RoomStatus } from 'src/room/entities/room.meta';
 import { RoomUser } from 'src/room/entities/room-user.entity';
 import { Room } from 'src/room/entities/room.entity';
+
+import {
+  RoomUserWithNicknameDto,
+  RoomWithUsersDto,
+} from './room-user-with-nickname.dto';
 
 describe('RoomUserWithNicknameDto', () => {
   const baseRoomUser = {
@@ -113,12 +117,13 @@ describe('RoomWithUsersDto', () => {
   });
 
   it('should handle room with one roomUser', () => {
-    const minimalRoom = { ...baseRoom, roomUsers: [roomUsers[0]] } as unknown as Room;
+    const minimalRoom = {
+      ...baseRoom,
+      roomUsers: [roomUsers[0]],
+    } as unknown as Room;
     const dto = new RoomWithUsersDto(minimalRoom);
     expect(Array.isArray(dto.roomUsers)).toBe(true);
     expect(dto.roomUsers).toHaveLength(1);
     expect(dto.roomUsers[0].nickname).toBe(roomUsers[0].user.nickname.nickname);
   });
 });
-
-

--- a/src/room/dto/room-user-with-nickname.dto.spec.ts
+++ b/src/room/dto/room-user-with-nickname.dto.spec.ts
@@ -1,0 +1,124 @@
+import { RoomUserWithNicknameDto, RoomWithUsersDto } from './room-user-with-nickname.dto';
+import { RoomUserStatus } from 'src/room/entities/room-user.meta';
+import { RoomStatus } from 'src/room/entities/room.meta';
+import { RoomUser } from 'src/room/entities/room-user.entity';
+import { Room } from 'src/room/entities/room.entity';
+
+describe('RoomUserWithNicknameDto', () => {
+  const baseRoomUser = {
+    userUuid: 'user-uuid-1',
+    roomUuid: 'room-uuid-1',
+    status: RoomUserStatus.JOINED,
+    isPaid: false,
+    kickedReason: 'some reason',
+    lastReadChatUuid: 'chat-uuid-1',
+    isMuted: false,
+    user: {
+      uuid: 'user-uuid-1',
+      nickname: { nickname: '포닉스' },
+    },
+  } as unknown as RoomUser;
+
+  it('should map basic fields and set nickname from user.nickname.nickname', () => {
+    const dto = new RoomUserWithNicknameDto(baseRoomUser);
+
+    expect(dto.userUuid).toBe(baseRoomUser.userUuid);
+    expect(dto.roomUuid).toBe(baseRoomUser.roomUuid);
+    expect(dto.status).toBe(baseRoomUser.status);
+    expect(dto.isPaid).toBe(baseRoomUser.isPaid);
+    expect(dto.lastReadChatUuid).toBe(baseRoomUser.lastReadChatUuid);
+    expect(dto.isMuted).toBe(baseRoomUser.isMuted);
+    expect(dto.nickname).toBe(baseRoomUser.user.nickname.nickname);
+  });
+
+  it('should omit kickedReason field', () => {
+    const dto = new RoomUserWithNicknameDto(baseRoomUser);
+    // @ts-expect-error - kickedReason should not exist on DTO shape
+    expect(dto.kickedReason).toBeUndefined();
+  });
+});
+
+describe('RoomWithUsersDto', () => {
+  const roomUsers: RoomUser[] = [
+    {
+      userUuid: 'user-uuid-1',
+      roomUuid: 'room-uuid-1',
+      status: RoomUserStatus.JOINED,
+      isPaid: false,
+      kickedReason: null,
+      lastReadChatUuid: 'chat-uuid-1',
+      isMuted: false,
+      user: {
+        uuid: 'user-uuid-1',
+        nickname: { nickname: '유저1' },
+      },
+    } as unknown as RoomUser,
+    {
+      userUuid: 'user-uuid-2',
+      roomUuid: 'room-uuid-1',
+      status: RoomUserStatus.JOINED,
+      isPaid: true,
+      kickedReason: null,
+      lastReadChatUuid: 'chat-uuid-2',
+      isMuted: true,
+      user: {
+        uuid: 'user-uuid-2',
+        nickname: { nickname: '유저2' },
+      },
+    } as unknown as RoomUser,
+  ];
+
+  const baseRoom = {
+    uuid: 'room-uuid-1',
+    title: '테스트 방',
+    ownerUuid: 'owner-uuid',
+    departureLocation: '출발지',
+    destinationLocation: '도착지',
+    maxParticipant: 4,
+    currentParticipant: 2,
+    departureTime: new Date(),
+    status: RoomStatus.ACTIVATED,
+    description: '설명',
+    payerUuid: null,
+    payAmount: null,
+    payerEncryptedAccountNumber: 'encrypted-account',
+    payerAccountHolderName: null,
+    payerBankName: null,
+    departureAlertSent: false,
+    roomUsers: roomUsers,
+  } as unknown as Room;
+
+  it('should map room fields and replace roomUsers with RoomUserWithNicknameDto[]', () => {
+    const payerAccountNumber = '123-456-7890';
+    const dto = new RoomWithUsersDto(baseRoom, payerAccountNumber);
+
+    expect(dto.uuid).toBe(baseRoom.uuid);
+    expect(dto.title).toBe(baseRoom.title);
+    expect(dto.payerAccountNumber).toBe(payerAccountNumber);
+
+    // original roomUsers removed from plain mapping, and replaced by DTO mapped list
+    expect(Array.isArray(dto.roomUsers)).toBe(true);
+    expect(dto.roomUsers).toHaveLength(2);
+    expect(dto.roomUsers[0].nickname).toBe(roomUsers[0].user.nickname.nickname);
+    expect(dto.roomUsers[1].nickname).toBe(roomUsers[1].user.nickname.nickname);
+  });
+
+  it('should exclude departureAlertSent and payerEncryptedAccountNumber from DTO', () => {
+    const payerAccountNumber = '123-456-7890';
+    const dto = new RoomWithUsersDto(baseRoom, payerAccountNumber);
+    // @ts-expect-error - should not exist on DTO
+    expect(dto.departureAlertSent).toBeUndefined();
+    // @ts-expect-error - should not exist on DTO
+    expect(dto.payerEncryptedAccountNumber).toBeUndefined();
+  });
+
+  it('should handle room with one roomUser', () => {
+    const minimalRoom = { ...baseRoom, roomUsers: [roomUsers[0]] } as unknown as Room;
+    const dto = new RoomWithUsersDto(minimalRoom);
+    expect(Array.isArray(dto.roomUsers)).toBe(true);
+    expect(dto.roomUsers).toHaveLength(1);
+    expect(dto.roomUsers[0].nickname).toBe(roomUsers[0].user.nickname.nickname);
+  });
+});
+
+

--- a/src/room/dto/room-user-with-nickname.dto.ts
+++ b/src/room/dto/room-user-with-nickname.dto.ts
@@ -25,27 +25,27 @@ export class RoomUserWithNicknameDto extends OmitType(RoomUser, [
 }
 
 export class RoomWithUsersDto extends OmitType(ResponseRoomDto, [
-  // 닉네임을 넣은 room_users를 만들기 위해 기존 room_users는 제외
-  'room_users',
+  // 닉네임을 넣은 roomUsers를 만들기 위해 기존 roomUsers는 제외
+  'roomUsers',
   'departureAlertSent',
 ]) {
   @ApiProperty({
     type: [RoomUserWithNicknameDto],
   })
-  room_users: RoomUserWithNicknameDto[];
+  roomUsers: RoomUserWithNicknameDto[];
 
   constructor(room: Room, payerAccountNumber?: string) {
     super();
     const plain = instanceToPlain(room) as Record<string, unknown>;
     const rest: Record<string, unknown> = { ...plain };
-    delete rest['room_users'];
+    delete rest['roomUsers'];
     delete rest['departureAlertSent'];
     delete rest['payerEncryptedAccountNumber'];
     Object.assign(this, rest);
 
     this.payerAccountNumber = payerAccountNumber;
 
-    this.room_users =
-      room.room_users?.map((ru) => new RoomUserWithNicknameDto(ru)) ?? [];
+    this.roomUsers =
+      room.roomUsers?.map((ru) => new RoomUserWithNicknameDto(ru)) ?? [];
   }
 }

--- a/src/room/entities/room-user.entity.ts
+++ b/src/room/entities/room-user.entity.ts
@@ -48,14 +48,14 @@ export class RoomUser extends Base {
    * Database Relation
    */
 
-  @ManyToOne(() => User, (user) => user.room_users, {
+  @ManyToOne(() => User, (user) => user.roomUsers, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'user_uuid', referencedColumnName: 'uuid' })
   @ApiHideProperty()
   user: User;
 
-  @ManyToOne(() => Room, (room) => room.room_users, {
+  @ManyToOne(() => Room, (room) => room.roomUsers, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'room_uuid', referencedColumnName: 'uuid' })

--- a/src/room/entities/room.entity.ts
+++ b/src/room/entities/room.entity.ts
@@ -85,23 +85,23 @@ export class Room extends Base {
    * Database Relation
    */
 
-  @ManyToOne(() => User, (user) => user.own_rooms, {
+  @ManyToOne(() => User, (user) => user.ownRooms, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'owner_uuid' })
   @ApiHideProperty()
   owner: User;
 
-  @ManyToOne(() => User, (user) => user.pay_rooms, {
+  @ManyToOne(() => User, (user) => user.payRooms, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'payer_uuid' })
   @ApiHideProperty()
   payer: User;
 
-  @OneToMany(() => RoomUser, (room_user) => room_user.room)
+  @OneToMany(() => RoomUser, (roomUser) => roomUser.room)
   @ApiHideProperty()
-  room_users: RoomUser[];
+  roomUsers: RoomUser[];
 
   @OneToMany(() => Chat, (chat) => chat.room)
   @ApiHideProperty()

--- a/src/room/room.integration.spec.ts
+++ b/src/room/room.integration.spec.ts
@@ -1087,7 +1087,7 @@ describe('RoomModule - Integration Test', () => {
       expect(result).toBeDefined();
       expect(result.sendMessage).toBe(true);
       expect(result.room.uuid).toBe(testRoom.uuid);
-      expect(result.room.room_users).toHaveLength(2); // 방장 + 참여한 사용자
+      expect(result.room.roomUsers).toHaveLength(2); // 방장 + 참여한 사용자
     });
 
     it('should throw BadRequestException when trying to join room in settlement', async () => {

--- a/src/user/entities/nickname.entity.ts
+++ b/src/user/entities/nickname.entity.ts
@@ -18,7 +18,7 @@ export class Nickname extends Base {
   @Exclude()
   id: number;
 
-  @Column({ name: 'user_uuid', type: 'uuid', nullable: false })
+  @Column({ name: 'user_uuid', type: 'uuid', nullable: false, unique: true })
   userUuid: string;
 
   @Column({ type: 'varchar', length: 20, nullable: false })

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -74,19 +74,19 @@ export class User extends Base {
 
   @OneToMany(() => Room, (room) => room.owner)
   @ApiHideProperty()
-  own_rooms: Room[];
+  ownRooms: Room[];
 
   @OneToMany(() => Room, (room) => room.payer)
   @ApiHideProperty()
-  pay_rooms: Room[];
+  payRooms: Room[];
 
-  @OneToMany(() => RoomUser, (room_user) => room_user.user)
+  @OneToMany(() => RoomUser, (roomUser) => roomUser.user)
   @ApiHideProperty()
-  room_users: RoomUser[];
+  roomUsers: RoomUser[];
 
-  @OneToMany(() => FcmKey, (fcm_key) => fcm_key.user)
+  @OneToMany(() => FcmKey, (fcmKey) => fcmKey.user)
   @ApiHideProperty()
-  push_keys: FcmKey[];
+  pushKeys: FcmKey[];
 
   @OneToMany(() => Chat, (chat) => chat.sender)
   @ApiHideProperty()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

https://github.com/PoApper/paxi-popo-nest-api/issues/129 (메인은 아님)


## 📝 작업 내용

https://github.com/PoApper/paxi-popo-nest-api/pull/118의 후속 PR

- entity relation들의 변수도 camelCase로 변경
- fcm_key에서 (userUuid, pushKey)를 unique로 설정. 유저가 복수 개의 push key 가질 수 있음. 개발 시에는 이게 맞는데, production에서는 pushKey 자체에 unique 두는 게 맞을듯 



### ✅ 테스트 여부 체크

- [x] 로컬 환경에서 기능이 잘 작동하는지 테스트를 진행했습니다
- [x] 테스트 코드를 작성했습니다
