### PR TITLE
Fix: Pad nickname digit part

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -199,7 +199,9 @@ export class UserService {
         adjectives[Math.floor(Math.random() * adjectives.length)];
       const noun = nouns[Math.floor(Math.random() * nouns.length)];
       const randomNumber = Math.floor(Math.random() * 10000);
-      const randomNickname = `${adjective}_${noun}_${randomNumber}`;
+      const randomNickname = `${adjective}_${noun}_${randomNumber
+        .toString()
+        .padStart(4, '0')}`;
       const hasTaken = await this.nicknameRepo.findOne({
         where: { nickname: randomNickname },
       });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

X

## 📝 작업 내용

닉네임 랜덤생성 숫자 부분 4자리로 고정
ex) 랜덤 숫자가 419라면 -> 0419

4자리로 검사하는 테스트가 실패함: https://github.com/PoApper/paxi-popo-nest-api/actions/runs/17527890369 

### ✅ 테스트 여부 체크

- [x] 로컬 환경에서 기능이 잘 작동하는지 테스트를 진행했습니다
- [x] 테스트 코드를 작성했습니다
