### PR TITLE
Fix: GET /room/:uuid에서 myRoomUser가 항상 undefined인 버그 수정

### DIFF
--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -198,8 +198,8 @@ export class RoomController {
     description: '복호화된 계좌번호가 포함된 방 정보를 반환',
     type: ResponseRoomDto,
   })
-  findOne(@Param('uuid') uuid: string) {
-    return this.roomService.findOneWithRoomUsers(uuid);
+  findOne(@User() user: JwtPayload, @Param('uuid') uuid: string) {
+    return this.roomService.findOneWithRoomUsers(uuid, user.uuid);
   }
 
   @Patch(':uuid')

--- a/src/room/room.integration.spec.ts
+++ b/src/room/room.integration.spec.ts
@@ -129,6 +129,62 @@ describe('RoomModule - Integration Test', () => {
     });
   });
 
+  describe('findOne', () => {
+    let testRoom: ResponseRoomDto;
+
+    beforeEach(async () => {
+      testRoom = await roomService.create(testUtils.getTestUser().uuid, {
+        description: '테스트 방입니다',
+        title: '테스트 방',
+        departureTime: new Date(Date.now() + 1000 * 60 * 60 * 24),
+        departureLocation: '출발지',
+        destinationLocation: '도착지',
+        maxParticipant: 4,
+      });
+    });
+
+    it('should return myRoomUser when user is a participant', async () => {
+      const result = await roomController.findOne(
+        testUtils.getTestUserJwtToken(),
+        testRoom.uuid,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.uuid).toBe(testRoom.uuid);
+      expect(result.myRoomUser).toBeDefined();
+      expect(result.myRoomUser!.status).toBe('JOINED');
+      expect(result.myRoomUser!.isMuted).toBe(false);
+      expect(result.myRoomUser!.isPaid).toBe(false);
+      expect(typeof result.myRoomUser!.hasNewMessage).toBe('boolean');
+    });
+
+    it('should return myRoomUser as undefined when user is not a participant', async () => {
+      const nonParticipant = await userService.save({
+        email: 'nonparticipant@test.com',
+        password: 'password123',
+        name: 'Non Participant',
+        userType: UserType.student,
+      });
+
+      const nonParticipantJwt: JwtPayload = {
+        uuid: nonParticipant.uuid,
+        email: nonParticipant.email,
+        name: nonParticipant.name,
+        nickname: 'non_participant',
+        userType: UserType.student,
+      };
+
+      const result = await roomController.findOne(
+        nonParticipantJwt,
+        testRoom.uuid,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.uuid).toBe(testRoom.uuid);
+      expect(result.myRoomUser).toBeUndefined();
+    });
+  });
+
   describe('settlement', () => {
     it('should create a requested settlement with an account number', async () => {
       const room = await roomService.create(testUtils.getTestUser().uuid, {


### PR DESCRIPTION
## Summary
- `GET /room/:uuid` 컨트롤러(`findOne`)에서 `@User()` 데코레이터가 누락되어 `userUuid`가 서비스에 전달되지 않았음
- 이로 인해 `myRoomUser`가 항상 `undefined`로 반환되어 프론트엔드에서 음소거, 강퇴 상태, 새 메시지 알림이 모두 동작하지 않았음
- `@User() user: JwtPayload`를 추가하고 `user.uuid`를 `findOneWithRoomUsers`에 전달하도록 수정

## 영향받는 프론트엔드 코드
| 파일 | 사용 내용 | 영향 |
|---|---|---|
| NewChatScreen.tsx | `myRoomUser?.isMuted` | 음소거 초기값 항상 false |
| TaxiChatList.tsx | `myRoomUser?.isMuted`, `status`, `hasNewMessage` | 음소거/강퇴/알림 미동작 |
| BanReasonModal.tsx | `myRoomUser?.kickedReason` | deprecated fallback 의존 |
| SidebarModal.tsx | `isMuted` prop | 음소거 토글 오작동 |

## Test plan
- [ ] `GET /room/:uuid` 호출 시 응답에 `myRoomUser` 객체가 포함되는지 확인
- [ ] `myRoomUser.isMuted`, `myRoomUser.status` 값이 정상 반환되는지 확인
- [ ] 방에 참여하지 않은 유저로 조회 시 `myRoomUser`가 `undefined`인지 확인