### PR TITLE
feat: 인증 흐름에 구조화된 보안 로깅 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Logger,
   Post,
   Req,
   Res,
@@ -25,10 +26,25 @@ const requiredRoles = [UserType.admin, UserType.association, UserType.staff];
 @PublicGuard([GuardName.NicknameGuard])
 @Controller('auth')
 export class AuthController {
+  private readonly logger = new Logger(AuthController.name);
+
   constructor(
     private readonly userService: UserService,
     private readonly authService: AuthService,
   ) {}
+
+  private getUserAgent(req: Request): string {
+    const userAgent = req.headers['user-agent'];
+    if (!userAgent) {
+      return '(알 수 없음)';
+    }
+
+    const normalizedUserAgent = Array.isArray(userAgent)
+      ? userAgent.join(', ')
+      : String(userAgent);
+
+    return normalizedUserAgent.replace(/[\r\n]/g, '');
+  }
 
   @Get(['verifyToken', 'verifyToken/admin'])
   verifyToken(@Req() req: Request) {
@@ -58,6 +74,14 @@ export class AuthController {
     const refreshTokenInCookie = req.cookies?.Refresh;
 
     if (!accessTokenInCookie || !refreshTokenInCookie) {
+      this.logger.warn(
+        [
+          '[토큰 갱신 실패: 쿠키 누락]',
+          `- Access Token 존재: ${!!accessTokenInCookie}`,
+          `- Refresh Token 존재: ${!!refreshTokenInCookie}`,
+          `- User-Agent: ${this.getUserAgent(req)}`,
+        ].join('\n'),
+      );
       this.clearCookies(res);
       throw new UnauthorizedException('Missing access token or refresh token');
     }
@@ -65,6 +89,12 @@ export class AuthController {
     // 만료된 access token을 디코딩 (JWT 가드 우회)
     const user = this.authService.decodeExpiredAccessToken(accessTokenInCookie);
     if (!user) {
+      this.logger.warn(
+        [
+          '[토큰 갱신 실패: Access Token 디코딩 실패]',
+          `- User-Agent: ${this.getUserAgent(req)}`,
+        ].join('\n'),
+      );
       this.clearCookies(res);
       throw new UnauthorizedException('Invalid access token');
     }
@@ -75,6 +105,14 @@ export class AuthController {
       refreshTokenInCookie,
     );
     if (!isValid) {
+      this.logger.warn(
+        [
+          '[토큰 갱신 실패: Refresh Token 검증 실패]',
+          `- 유저 UUID: ${user.uuid}`,
+          `- 이메일: ${user.email}`,
+          `- User-Agent: ${this.getUserAgent(req)}`,
+        ].join('\n'),
+      );
       await this.userService.updateRefreshToken(user.uuid, null, null);
       this.clearCookies(res);
       throw new UnauthorizedException('Invalid refresh token');
@@ -84,6 +122,15 @@ export class AuthController {
     const refreshToken = await this.authService.generateRefreshToken(user);
 
     this.setCookies(res, accessToken, refreshToken);
+
+    this.logger.log(
+      [
+        '[토큰 갱신 성공]',
+        `- 유저 UUID: ${user.uuid}`,
+        `- 이메일: ${user.email}`,
+        `- User-Agent: ${this.getUserAgent(req)}`,
+      ].join('\n'),
+    );
 
     return user;
   }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Get,
-  Logger,
   Post,
   Req,
   Res,
@@ -18,6 +17,7 @@ import { UserService } from 'src/user/user.service';
 
 import { JwtPayload } from './strategies/jwt.payload';
 import { AuthService } from './auth.service';
+import { AuthLogger } from './auth.logger';
 import { jwtConstants } from './constants';
 
 const requiredRoles = [UserType.admin, UserType.association, UserType.staff];
@@ -26,7 +26,7 @@ const requiredRoles = [UserType.admin, UserType.association, UserType.staff];
 @PublicGuard([GuardName.NicknameGuard])
 @Controller('auth')
 export class AuthController {
-  private readonly logger = new Logger(AuthController.name);
+  private readonly logger = new AuthLogger(AuthController.name);
 
   constructor(
     private readonly userService: UserService,
@@ -74,14 +74,11 @@ export class AuthController {
     const refreshTokenInCookie = req.cookies?.Refresh;
 
     if (!accessTokenInCookie || !refreshTokenInCookie) {
-      this.logger.warn(
-        [
-          '[토큰 갱신 실패: 쿠키 누락]',
-          `- Access Token 존재: ${!!accessTokenInCookie}`,
-          `- Refresh Token 존재: ${!!refreshTokenInCookie}`,
-          `- User-Agent: ${this.getUserAgent(req)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('토큰 갱신 실패: 쿠키 누락', {
+        'Access Token 존재': !!accessTokenInCookie,
+        'Refresh Token 존재': !!refreshTokenInCookie,
+        'User-Agent': this.getUserAgent(req),
+      });
       this.clearCookies(res);
       throw new UnauthorizedException('Missing access token or refresh token');
     }
@@ -89,12 +86,9 @@ export class AuthController {
     // 만료된 access token을 디코딩 (JWT 가드 우회)
     const user = this.authService.decodeExpiredAccessToken(accessTokenInCookie);
     if (!user) {
-      this.logger.warn(
-        [
-          '[토큰 갱신 실패: Access Token 디코딩 실패]',
-          `- User-Agent: ${this.getUserAgent(req)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('토큰 갱신 실패: Access Token 디코딩 실패', {
+        'User-Agent': this.getUserAgent(req),
+      });
       this.clearCookies(res);
       throw new UnauthorizedException('Invalid access token');
     }
@@ -105,14 +99,11 @@ export class AuthController {
       refreshTokenInCookie,
     );
     if (!isValid) {
-      this.logger.warn(
-        [
-          '[토큰 갱신 실패: Refresh Token 검증 실패]',
-          `- 유저 UUID: ${user.uuid}`,
-          `- 이메일: ${user.email}`,
-          `- User-Agent: ${this.getUserAgent(req)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('토큰 갱신 실패: Refresh Token 검증 실패', {
+        '유저 UUID': user.uuid,
+        이메일: user.email,
+        'User-Agent': this.getUserAgent(req),
+      });
       await this.userService.updateRefreshToken(user.uuid, null, null);
       this.clearCookies(res);
       throw new UnauthorizedException('Invalid refresh token');
@@ -123,14 +114,11 @@ export class AuthController {
 
     this.setCookies(res, accessToken, refreshToken);
 
-    this.logger.log(
-      [
-        '[토큰 갱신 성공]',
-        `- 유저 UUID: ${user.uuid}`,
-        `- 이메일: ${user.email}`,
-        `- User-Agent: ${this.getUserAgent(req)}`,
-      ].join('\n'),
-    );
+    this.logger.log('토큰 갱신 성공', {
+      '유저 UUID': user.uuid,
+      이메일: user.email,
+      'User-Agent': this.getUserAgent(req),
+    });
 
     return user;
   }

--- a/src/auth/auth.logger.ts
+++ b/src/auth/auth.logger.ts
@@ -1,0 +1,38 @@
+import { Logger } from '@nestjs/common';
+
+type LogFieldValue = string | number | boolean | null | undefined;
+type LogFields = Record<string, LogFieldValue>;
+
+export class AuthLogger {
+  private readonly logger: Logger;
+
+  constructor(context: string) {
+    this.logger = new Logger(context);
+  }
+
+  log(event: string, fields: LogFields): void {
+    this.logger.log(this.format(event, fields));
+  }
+
+  warn(event: string, fields: LogFields): void {
+    this.logger.warn(this.format(event, fields));
+  }
+
+  error(event: string, fields: LogFields, stack?: string): void {
+    this.logger.error(this.format(event, fields), stack);
+  }
+
+  private format(event: string, fields: LogFields): string {
+    const lines = [`[${event}]`];
+    for (const [key, value] of Object.entries(fields)) {
+      lines.push(`- ${key}: ${this.sanitize(value)}`);
+    }
+    return lines.join('\n');
+  }
+
+  private sanitize(value: LogFieldValue): string {
+    if (value == null) return '(없음)';
+    const str = String(value);
+    return str.replace(/[\r\n]/g, '');
+  }
+}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -79,14 +79,42 @@ export class AuthService {
 
       // 2. 리프레시 토큰의 payload가 액세스 토큰의 정보와 일치하는지 검증
       if (userInRefreshToken.uuid !== userInAccessToken.uuid) {
+        this.logger.warn(
+          [
+            '[토큰 갱신 실패: UUID 불일치]',
+            `- Access Token UUID: ${userInAccessToken.uuid}`,
+            `- Refresh Token UUID: ${userInRefreshToken.uuid}`,
+            `- 이메일: ${userInAccessToken.email}`,
+          ].join('\n'),
+        );
         return false;
       }
 
       // 3. DB에 저장된 해시된 리프레시 토큰과 일치하는지 검증
-      const user = (await this.userService.findOne(userInAccessToken.uuid))!;
+      const user = await this.userService.findOne(userInAccessToken.uuid);
+
+      if (!user) {
+        this.logger.warn(
+          [
+            '[토큰 갱신 실패: 존재하지 않는 유저]',
+            `- 유저 UUID: ${userInAccessToken.uuid}`,
+            `- 이메일: ${userInAccessToken.email}`,
+          ].join('\n'),
+        );
+        return false;
+      }
+
       const hashedToken = this.hashToken(refreshToken);
 
       if (!user.hashedRefreshToken || user.hashedRefreshToken !== hashedToken) {
+        this.logger.warn(
+          [
+            '[토큰 갱신 실패: Refresh Token 해시 불일치]',
+            `- 유저 UUID: ${userInAccessToken.uuid}`,
+            `- 이메일: ${userInAccessToken.email}`,
+            `- DB에 토큰 존재 여부: ${!!user.hashedRefreshToken}`,
+          ].join('\n'),
+        );
         return false;
       }
 
@@ -95,13 +123,28 @@ export class AuthService {
         !user.refreshTokenExpiresAt ||
         user.refreshTokenExpiresAt <= new Date()
       ) {
+        this.logger.warn(
+          [
+            '[토큰 갱신 실패: Refresh Token 만료]',
+            `- 유저 UUID: ${userInAccessToken.uuid}`,
+            `- 이메일: ${userInAccessToken.email}`,
+            `- 만료 시각: ${user.refreshTokenExpiresAt?.toISOString() ?? '(없음)'}`,
+          ].join('\n'),
+        );
         return false;
       }
 
       return true;
     } catch (error) {
       // 토큰 검증 실패 (만료되었거나 서명이 잘못된 경우)
-      this.logger.error('리프레시 토큰 검증 실패:', error);
+      this.logger.warn(
+        [
+          '[토큰 갱신 실패: Refresh Token 서명 검증 실패]',
+          `- 유저 UUID: ${userInAccessToken.uuid}`,
+          `- 이메일: ${userInAccessToken.email}`,
+          `- 에러: ${error instanceof Error ? error.message : String(error)}`,
+        ].join('\n'),
+      );
       return false;
     }
   }
@@ -123,7 +166,12 @@ export class AuthService {
         userType: payload.userType,
       };
     } catch (error) {
-      this.logger.error('액세스 토큰 디코딩 실패:', error);
+      this.logger.warn(
+        [
+          '[Access Token 디코딩 실패]',
+          `- 에러: ${error instanceof Error ? error.message : String(error)}`,
+        ].join('\n'),
+      );
       return null;
     }
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Response } from 'express';
 import * as ms from 'ms';
@@ -7,6 +7,7 @@ import * as crypto from 'crypto';
 import { UserService } from 'src/user/user.service';
 
 import { JwtPayload } from './strategies/jwt.payload';
+import { AuthLogger } from './auth.logger';
 import { jwtConstants } from './constants';
 
 @Injectable()
@@ -15,7 +16,7 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly userService: UserService,
   ) {}
-  private readonly logger = new Logger(AuthService.name);
+  private readonly logger = new AuthLogger(AuthService.name);
 
   generateAccessToken(user: JwtPayload) {
     const payload = {
@@ -79,14 +80,11 @@ export class AuthService {
 
       // 2. 리프레시 토큰의 payload가 액세스 토큰의 정보와 일치하는지 검증
       if (userInRefreshToken.uuid !== userInAccessToken.uuid) {
-        this.logger.warn(
-          [
-            '[토큰 갱신 실패: UUID 불일치]',
-            `- Access Token UUID: ${userInAccessToken.uuid}`,
-            `- Refresh Token UUID: ${userInRefreshToken.uuid}`,
-            `- 이메일: ${userInAccessToken.email}`,
-          ].join('\n'),
-        );
+        this.logger.warn('토큰 갱신 실패: UUID 불일치', {
+          'Access Token UUID': userInAccessToken.uuid,
+          'Refresh Token UUID': userInRefreshToken.uuid,
+          이메일: userInAccessToken.email,
+        });
         return false;
       }
 
@@ -94,27 +92,21 @@ export class AuthService {
       const user = await this.userService.findOne(userInAccessToken.uuid);
 
       if (!user) {
-        this.logger.warn(
-          [
-            '[토큰 갱신 실패: 존재하지 않는 유저]',
-            `- 유저 UUID: ${userInAccessToken.uuid}`,
-            `- 이메일: ${userInAccessToken.email}`,
-          ].join('\n'),
-        );
+        this.logger.warn('토큰 갱신 실패: 존재하지 않는 유저', {
+          '유저 UUID': userInAccessToken.uuid,
+          이메일: userInAccessToken.email,
+        });
         return false;
       }
 
       const hashedToken = this.hashToken(refreshToken);
 
       if (!user.hashedRefreshToken || user.hashedRefreshToken !== hashedToken) {
-        this.logger.warn(
-          [
-            '[토큰 갱신 실패: Refresh Token 해시 불일치]',
-            `- 유저 UUID: ${userInAccessToken.uuid}`,
-            `- 이메일: ${userInAccessToken.email}`,
-            `- DB에 토큰 존재 여부: ${!!user.hashedRefreshToken}`,
-          ].join('\n'),
-        );
+        this.logger.warn('토큰 갱신 실패: Refresh Token 해시 불일치', {
+          '유저 UUID': userInAccessToken.uuid,
+          이메일: userInAccessToken.email,
+          'DB에 토큰 존재 여부': !!user.hashedRefreshToken,
+        });
         return false;
       }
 
@@ -123,28 +115,22 @@ export class AuthService {
         !user.refreshTokenExpiresAt ||
         user.refreshTokenExpiresAt <= new Date()
       ) {
-        this.logger.warn(
-          [
-            '[토큰 갱신 실패: Refresh Token 만료]',
-            `- 유저 UUID: ${userInAccessToken.uuid}`,
-            `- 이메일: ${userInAccessToken.email}`,
-            `- 만료 시각: ${user.refreshTokenExpiresAt?.toISOString() ?? '(없음)'}`,
-          ].join('\n'),
-        );
+        this.logger.warn('토큰 갱신 실패: Refresh Token 만료', {
+          '유저 UUID': userInAccessToken.uuid,
+          이메일: userInAccessToken.email,
+          '만료 시각': user.refreshTokenExpiresAt?.toISOString(),
+        });
         return false;
       }
 
       return true;
     } catch (error) {
       // 토큰 검증 실패 (만료되었거나 서명이 잘못된 경우)
-      this.logger.warn(
-        [
-          '[토큰 갱신 실패: Refresh Token 서명 검증 실패]',
-          `- 유저 UUID: ${userInAccessToken.uuid}`,
-          `- 이메일: ${userInAccessToken.email}`,
-          `- 에러: ${error instanceof Error ? error.message : String(error)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('토큰 갱신 실패: Refresh Token 서명 검증 실패', {
+        '유저 UUID': userInAccessToken.uuid,
+        이메일: userInAccessToken.email,
+        에러: error instanceof Error ? error.message : String(error),
+      });
       return false;
     }
   }
@@ -166,12 +152,9 @@ export class AuthService {
         userType: payload.userType,
       };
     } catch (error) {
-      this.logger.warn(
-        [
-          '[Access Token 디코딩 실패]',
-          `- 에러: ${error instanceof Error ? error.message : String(error)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('Access Token 디코딩 실패', {
+        에러: error instanceof Error ? error.message : String(error),
+      });
       return null;
     }
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

없음

## 📝 작업 내용

인증/토큰 갱신 흐름에서 보안 이벤트 추적을 위한 구조화된 로깅을 추가합니다.
기존에는 토큰 갱신 실패 시 원인 파악이 어려웠습니다 (예: `jwt malformed` 에러의 원인 추적 불가).

### 변경 전
- `AuthService`에서 `logger.error('리프레시 토큰 검증 실패:', error)` 형태의 비구조화 로깅
- `AuthController`의 토큰 갱신 실패 경로에 로깅 없음
- `validateRefreshToken`에서 유저 미존재 시 null 체크 없이 `!` assertion 사용

### 변경 후
- **`AuthController.refresh`**: 쿠키 누락/디코딩 실패/검증 실패/성공 4가지 경로에 구조화된 로깅 (User-Agent 포함)
- **`AuthService.validateRefreshToken`**: 5단계별 warn 로깅 (UUID 불일치, 유저 미존재, 해시 불일치, 만료, 서명 실패)
- **`AuthService.decodeExpiredAccessToken`**: 디코딩 실패 warn 로깅
- `getUserAgent()` 헬퍼로 CRLF 로그 인젝션 방지
- `findOne()` 결과 null 체크 추가 (non-null assertion 제거)

### 로깅 정책
| 허용 | 금지 |
|---|---|
| 이메일, UUID, User-Agent | 이름, IP, 비밀번호, 토큰 값 |

| 로그 레벨 | 용도 |
|---|---|
| `log` | 성공 이벤트 (토큰 갱신 성공) |
| `warn` | 인증 실패 이벤트 |

### ✅ 테스트 여부 체크

- [x] 로컬 환경에서 기능이 잘 작동하는지 테스트를 진행했습니다
- [ ] 테스트 코드를 작성했습니다

### 🖥️ 스크린샷 (선택)

해당 없음 (로깅만 추가, 동작 변경 없음)

## 💬 리뷰 요구사항 (선택)

- `[이벤트]\n- 키: 값` 로깅 포맷이 PoApper/popo-nest-api#211 와 동일한 형식입니다
- 동작 로직 변경은 `validateRefreshToken`의 유저 null 체크 추가뿐입니다